### PR TITLE
PandaCSSのstyled-systemのエイリアスパスを変更した

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import { useState } from "preact/hooks";
 
-import { css } from "@styles/css";
-import { flex } from "@styles/patterns";
+import { css } from "@styles/styled-system/css";
+import { flex } from "@styles/styled-system/patterns";
 
 import { SubmitButton } from "~/components/BaseButton";
 import { Heading2 } from "./components/Heading2";

--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -1,5 +1,5 @@
 import { JSX } from "preact/jsx-runtime";
-import { css } from "@styles/css";
+import { css } from "@styles/styled-system/css";
 
 export function SubmitButton({ text, ...props }: JSX.IntrinsicElements["button"] & { text: string }) {
   return (

--- a/src/components/DoneBadge.tsx
+++ b/src/components/DoneBadge.tsx
@@ -1,4 +1,4 @@
-import { css } from "@styles/css";
+import { css } from "@styles/styled-system/css";
 
 export function DoneBadge({ isDone }: { isDone: boolean }) {
   const style = css({

--- a/src/components/Heading2.tsx
+++ b/src/components/Heading2.tsx
@@ -1,4 +1,4 @@
-import { css } from "@styles/css";
+import { css } from "@styles/styled-system/css";
 
 export function Heading2({ title }: { title: string }) {
   return <h2 className={css({ fontSize: "x-large", fontWeight: "bold", color: "gray.600" })}>{title}</h2>;

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
-import { css } from "@styles/css";
-import { flex } from "@styles/patterns";
+import { css } from "@styles/styled-system/css";
+import { flex } from "@styles/styled-system/patterns";
 
 export function NavigationBar({ name, logoSrc, logoAlt }: { name: string; logoSrc: string; logoAlt: string }) {
   return (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,7 +1,7 @@
 import { ComponentChildren } from "preact";
 import { useState } from "preact/hooks";
-import { css } from "@styles/css";
-import { flex } from "@styles/patterns";
+import { css } from "@styles/styled-system/css";
+import { flex } from "@styles/styled-system/patterns";
 import { DoneBadge } from "~/components/DoneBadge";
 
 function DraggableElement({

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import { JSX } from "preact/jsx-runtime";
-import { css } from "@styles/css";
+import { css } from "@styles/styled-system/css";
 
 export function TextInput(props: JSX.IntrinsicElements["input"]) {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "jsxImportSource": "preact",
     "baseUrl": ".",
     "paths": {
-      "@styles/*": ["styled-system/*"],
+      "@styles/styled-system/*": ["styled-system/*"],
       "~/*": ["src/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "src"),
-      "@styles": path.resolve(__dirname, "styled-system"),
+      "@styles/styled-system": path.resolve(__dirname, "styled-system"),
     },
   },
   plugins: [preact()],


### PR DESCRIPTION
エイリアス貼った場合に `styled-system/patterns`
とかを使って生成するcssが適用されない問題がある
https://github.com/chakra-ui/panda/discussions/980

エイリアスで指定する階層を一つ増やすと動いたので一旦そうしておく
